### PR TITLE
Update to handle multiple targets

### DIFF
--- a/featuretools_ta1/multi_table.py
+++ b/featuretools_ta1/multi_table.py
@@ -137,7 +137,8 @@ class MultiTableFeaturization(UnsupervisedLearnerPrimitiveBase[Inputs, Outputs, 
         # if there is a target column on the target entity, ignore it
         target_column = find_target_column(self._inputs[self._target_resource_id], return_index=False)
         if target_column:
-            ignore_variables = {self._target_resource_id: [target_column]}
+            #ignore_variables = {self._target_resource_id: [target_column]}
+            ignore_variables = {self._target_resource_id: target_column}
 
 
         # generate all the features
@@ -163,7 +164,7 @@ class MultiTableFeaturization(UnsupervisedLearnerPrimitiveBase[Inputs, Outputs, 
         self.features = features
 
         fm = add_metadata(fm, self.features)
-        
+
         self._fitted = True
 
         return CallResult(fm)
@@ -206,7 +207,7 @@ class MultiTableFeaturization(UnsupervisedLearnerPrimitiveBase[Inputs, Outputs, 
 
         # if a target is found,
         if target_index is not None:
-            labels = inputs[self._target_resource_id].select_columns([target_index])
+            labels = inputs[self._target_resource_id].select_columns(target_index)
             fm = fm.append_columns(labels)
 
         return fm

--- a/featuretools_ta1/multi_table.py
+++ b/featuretools_ta1/multi_table.py
@@ -137,7 +137,6 @@ class MultiTableFeaturization(UnsupervisedLearnerPrimitiveBase[Inputs, Outputs, 
         # if there is a target column on the target entity, ignore it
         target_column = find_target_column(self._inputs[self._target_resource_id], return_index=False)
         if target_column:
-            #ignore_variables = {self._target_resource_id: [target_column]}
             ignore_variables = {self._target_resource_id: target_column}
 
 

--- a/featuretools_ta1/single_table.py
+++ b/featuretools_ta1/single_table.py
@@ -167,7 +167,7 @@ class SingleTableFeaturization(UnsupervisedLearnerPrimitiveBase[Inputs, Outputs,
         target_index = find_target_column(inputs, return_index=True)
         # if a target is found,
         if target_index is not None:
-            labels = inputs.select_columns([target_index])
+            labels = inputs.select_columns(target_index)
             fm = fm.append_columns(labels)
 
         return CallResult(fm)

--- a/featuretools_ta1/utils.py
+++ b/featuretools_ta1/utils.py
@@ -77,15 +77,19 @@ def find_target_column(resource_df, return_index=False):
     # todo: refactor this since it share some logic with other functions
     num_columns = resource_df.metadata.query(["ALL_ELEMENTS"])["dimension"]["length"]
 
+    col_list = []
     for i in range(num_columns):
         metadata = resource_df.metadata.query(["ALL_ELEMENTS", i])
         semantic_types = metadata["semantic_types"]
         col_name = metadata["name"]
         if st.TARGET in semantic_types or st.TRUE_TARGET in semantic_types:
             if return_index:
-                return i
-
-            return col_name
+                col_list.append(i)
+            else:
+                col_list.append(col_name)
+        
+    if col_list:
+        return col_list
 
     return None
 

--- a/pipeline_tests/test_uu2_gp_hyperparameter_estimation.py
+++ b/pipeline_tests/test_uu2_gp_hyperparameter_estimation.py
@@ -1,0 +1,80 @@
+from d3m import index
+from d3m.metadata.base import ArgumentType
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+from d3m.primitives.feature_construction.deep_feature_synthesis import SingleTableFeaturization
+from d3m.primitives.feature_construction.deep_feature_synthesis import MultiTableFeaturization
+from d3m.primitives.data_transformation import column_parser
+import os
+
+
+def generate_only():
+    # -> dataset_to_dataframe -> column_parser -> extract_columns_by_semantic_types(attributes) -> imputer -> random_forest
+    #                                             extract_columns_by_semantic_types(targets)    ->            ^
+
+    # Creating pipeline
+    pipeline_description = Pipeline()
+    pipeline_description.add_input(name='inputs')
+
+    # Step 0: Parse columns
+    step_0 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.operator.dataset_map.DataFrameCommon'))
+    step_0.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='inputs.0')
+    step_0.add_hyperparameter(name='primitive', argument_type=ArgumentType.VALUE,
+                            data=column_parser.DataFrameCommon)
+    step_0.add_hyperparameter(name='resources', argument_type=ArgumentType.VALUE,
+                            data='all')
+    step_0.add_hyperparameter(name='fit_primitive', argument_type=ArgumentType.VALUE,
+                            data='no')
+    step_0.add_output('produce')
+    pipeline_description.add_step(step_0)
+
+    # Step 1: MultiTableFeaturization
+    step_1 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.feature_construction.deep_feature_synthesis.MultiTableFeaturization'))
+    step_1.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.0.produce')
+    step_1.add_output('produce')
+    pipeline_description.add_step(step_1)
+
+    # Step 2: DFS Single Table
+    step_2 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.feature_construction.deep_feature_synthesis.SingleTableFeaturization'))
+    step_2.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
+    step_2.add_output('produce')
+    pipeline_description.add_step(step_2)
+
+
+    # Step 3: imputer
+    step_3 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_cleaning.imputer.SKlearn'))
+    step_3.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference="steps.2.produce")
+    step_3.add_hyperparameter(name='use_semantic_types', argument_type=ArgumentType.VALUE, data=True)
+    step_3.add_output('produce')
+    pipeline_description.add_step(step_3)
+
+
+    # Step 4: learn model
+    step_4 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.classification.xgboost_gbtree.DataFrameCommon'))
+    step_4.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.3.produce')
+    step_4.add_argument(name='outputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
+    step_4.add_output('produce')
+    pipeline_description.add_step(step_4)
+
+    # step 5: construct output
+    step_5 = PrimitiveStep(primitive=index.get_primitive('d3m.primitives.data_transformation.construct_predictions.DataFrameCommon'))
+    step_5.add_argument(name='inputs', argument_type=ArgumentType.CONTAINER, data_reference='steps.4.produce')
+    step_5.add_argument(name='reference', argument_type=ArgumentType.CONTAINER, data_reference='steps.1.produce')
+    step_5.add_output('produce')
+    pipeline_description.add_step(step_5)
+
+    # Final Output
+    pipeline_description.add_output(name='output predictions', data_reference='steps.5.produce')
+
+    # Generate .yml and .meta files for the pipeline
+    from pipeline_tests.utils import generate_pipeline
+    yml, meta = generate_pipeline(primitive_name='d3m.primitives.feature_construction.deep_feature_synthesis.MultiTableFeaturization',
+                                  pipeline_description = pipeline_description,
+                                  dataset_name='uu2_gp_hyperparameter_estimation')
+
+    return yml, meta
+
+if __name__ == "__main__":
+    yml, meta = generate_only()
+    print("Running test...")
+    cmd = 'python3 -m d3m runtime -d /featuretools_ta1/datasets/ evaluate -m {} -p {} -d /pipeline_tests/kfold_pipeline.yml'.format(meta, yml)
+    os.system(cmd)

--- a/run_pipelines.sh
+++ b/run_pipelines.sh
@@ -8,7 +8,10 @@ for ymlfile in $ST_OUTDIR/pipelines/*.yml
 do
   echo "Running $ymlfile"
   metafile="${ymlfile%.*}.meta"
+  echo "FIT-SCORE"
   python3 -m d3m runtime -d /featuretools_ta1/datasets/ fit-score -m $metafile -p $ymlfile
+  echo "EVALUATE"
+  python3 -m d3m runtime -d /featuretools_ta1/datasets/ evaluate -m $metafile -p $ymlfile -d /pipeline_tests/kfold_pipeline.yml
 done
 
 # Run pipeline and score - Multi Table
@@ -17,5 +20,8 @@ for ymlfile in $MT_OUTDIR/pipelines/*.yml
 do
   echo "Running $ymlfile"
   metafile="${ymlfile%.*}.meta"
+  echo "FIT-SCORE"
   python3 -m d3m runtime -d /featuretools_ta1/datasets/ fit-score -m $metafile -p $ymlfile
+  echo "EVALUATE"
+  python3 -m d3m runtime -d /featuretools_ta1/datasets/ evaluate -m $metafile -p $ymlfile -d /pipeline_tests/kfold_pipeline.yml
 done


### PR DESCRIPTION
Made updates to `multi_table.py`, `single_table.py` and `utils.py` to handle situations where multiple targets are specified. Instead of returning a single target `find_target_column` now returns a list of target columns (or column ids).

Also updated `run_pipelines.sh` to do both `fit-score` and `evaluate` for each pipeline.