### PR TITLE
Updates for select_one_of_correlated

### DIFF
--- a/featuretools_ta1/utils.py
+++ b/featuretools_ta1/utils.py
@@ -23,14 +23,12 @@ def select_one_of_correlated(fm, features, threshold=.9, verbose=False):
 
     corr = fm.corr().abs()
     cols = corr.columns
-    keep_cols = []
     to_drop = set()
 
     for c in cols:
         if c in to_drop:
             continue
         drop = corr[corr[c] > threshold].index
-        keep_cols.append(c)
         for d in drop:
             if d != c:
                 to_drop.add(d)

--- a/featuretools_ta1/utils.py
+++ b/featuretools_ta1/utils.py
@@ -24,7 +24,7 @@ def select_one_of_correlated(fm, features, threshold=.9, verbose=False):
     corr = fm.corr().abs()
     cols = corr.columns
     keep_cols = []
-    to_drop = []
+    to_drop = set()
 
     for c in cols:
         if c in to_drop:
@@ -33,7 +33,7 @@ def select_one_of_correlated(fm, features, threshold=.9, verbose=False):
         keep_cols.append(c)
         for d in drop:
             if d != c:
-                to_drop.append(d)
+                to_drop.add(d)
     features = [f for f in features if f.get_name() not in to_drop]
     fm = fm[[f.get_name() for f in features]]
 


### PR DESCRIPTION
* Make `to_drop` a set instead of a list, avoiding a bug where a feature could be added to `to_drop` multiple times, causing the function to report an incorrect number of dropped features if `verbose` was True
* Remove `keep_cols` since it is not used